### PR TITLE
Add cflinuxfs5 support for Python buildpack

### DIFF
--- a/jobs/python-buildpack/spec
+++ b/jobs/python-buildpack/spec
@@ -3,6 +3,7 @@ name: python-buildpack
 templates: {}
 
 packages:
+- python-buildpack-cflinuxfs5
 - python-buildpack-cflinuxfs4
 
 properties: {}

--- a/packages/python-buildpack-cflinuxfs5/packaging
+++ b/packages/python-buildpack-cflinuxfs5/packaging
@@ -1,0 +1,2 @@
+    set -e -x
+    cp python-buildpack/python?buildpack-*.zip ${BOSH_INSTALL_TARGET}

--- a/packages/python-buildpack-cflinuxfs5/spec
+++ b/packages/python-buildpack-cflinuxfs5/spec
@@ -1,0 +1,4 @@
+---
+name: python-buildpack-cflinuxfs5
+files:
+- python-buildpack/python?buildpack-cflinuxfs5-*.zip


### PR DESCRIPTION
This commit adds cflinuxfs5 (Ubuntu 24.04 noble) stack support to the python-buildpack BOSH release, following the same pattern used for cflinuxfs4.

Changes:
- Create packages/python-buildpack-cflinuxfs5/spec - package specification
- Create packages/python-buildpack-cflinuxfs5/packaging - build script
- Update jobs/python-buildpack/spec to reference cflinuxfs5 package

Both cflinuxfs4 and cflinuxfs5 packages will be included in future releases, enabling operators to deploy Python applications on either stack during the migration period from jammy (cflinuxfs4) to noble (cflinuxfs5).

The next BOSH release will include the cflinuxfs5 package, making it available for Cloud Foundry deployments.